### PR TITLE
fix(client/zones): debug erroneously triggers zone:inside

### DIFF
--- a/imports/zones/client.lua
+++ b/imports/zones/client.lua
@@ -266,7 +266,7 @@ CreateThread(function()
 
 
 						if zone.debug then
-							if zone.inside then zone:inside() end
+							if zone.insideZone then zone:inside() end
 
 							zone:debug()
 						elseif zone.insideZone then


### PR DESCRIPTION
Should only trigger when the player is, in fact, inside the zone.